### PR TITLE
Display command on verify output

### DIFF
--- a/src/Collections/ScheduledTaskCollection.php
+++ b/src/Collections/ScheduledTaskCollection.php
@@ -23,9 +23,10 @@ class ScheduledTaskCollection extends Collection
                 return [
                     'mutex' => $task['mutex'],
                     'type' => $task['type'],
+                    'command' => $command = $task['command'] ?: $task['description'],
                     'expression' => $task['expression'],
                     'interval' => Thenpingme::translateExpression($task['expression']),
-                    'description' => $task['description'],
+                    'description' => $task['description'] !== $command ? $task['description'] : null,
                     'extra' => $task['type'] == 'closure' && isset($task['extra'])
                         ? sprintf('Line %s of %s', $task['extra']['line'], $task['extra']['file'])
                         : null,

--- a/src/Console/Commands/ThenpingmeVerifyCommand.php
+++ b/src/Console/Commands/ThenpingmeVerifyCommand.php
@@ -27,9 +27,9 @@ class ThenpingmeVerifyCommand extends Command
     {
         if (($collisions = Thenpingme::scheduledTasks()->collisions())->isNotEmpty()) {
             $this->table(
-                ['Type', 'Expression', 'Interval', 'Description', 'Extra'],
+                ['Type', 'Command', 'Expression', 'Interval', 'Description', 'Extra'],
                 $collisions->map(function ($task) {
-                    return Arr::only($task, ['type', 'expression', 'interval', 'description', 'extra']);
+                    return Arr::only($task, ['type', 'command', 'expression', 'interval', 'description', 'extra']);
                 })
             );
 


### PR DESCRIPTION
The `thenpingme:verify` command was not showing the command or description for a scheduled task, so it was not actually very useful in identifying _what_ was colliding.