### PR TITLE
Make thenpingme:setup command dispatch immediately for instant feedback

### DIFF
--- a/src/Console/Commands/ThenpingmeSetupCommand.php
+++ b/src/Console/Commands/ThenpingmeSetupCommand.php
@@ -171,13 +171,17 @@ class ThenpingmeSetupCommand extends Command
 
     protected function setupInitialTasks(): bool
     {
+        config(['thenpingme.queue_ping' => false]);
+
         app(Client::class)
             ->setup()
             ->useSecret($this->option('tasks-only') ? Config::get('thenpingme.project_id') : $this->argument('project_id'))
-            ->payload(ThenpingmeSetupPayload::make(
-                Thenpingme::scheduledTasks(),
-                Config::get('thenpingme.signing_key') ?: $this->signingKey
-            )->toArray())
+            ->payload(
+                ThenpingmeSetupPayload::make(
+                    Thenpingme::scheduledTasks(),
+                    Config::get('thenpingme.signing_key') ?: $this->signingKey
+                )->toArray()
+            )
             ->dispatch();
 
         return true;

--- a/tests/ThenpingmeSyncTest.php
+++ b/tests/ThenpingmeSyncTest.php
@@ -4,11 +4,11 @@ namespace Thenpingme\Tests;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Translation\Translator;
-use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Str;
-use Thenpingme\Client\Client;
 use Thenpingme\Collections\ScheduledTaskCollection;
 use Thenpingme\Facades\Thenpingme;
+use Thenpingme\ThenpingmePingJob;
 
 class ThenpingmeSyncTest extends TestCase
 {
@@ -21,14 +21,14 @@ class ThenpingmeSyncTest extends TestCase
 
         $this->translator = $this->app->make(Translator::class);
 
-        Queue::fake();
-
         config(['thenpingme.api_url' => 'http://thenpingme.test/api']);
     }
 
     /** @test */
     public function it_fetches_tasks_to_be_synced()
     {
+        Bus::fake();
+
         config(['thenpingme.queue_ping' => true]);
 
         tap($this->app->make(Schedule::class), function ($schedule) {
@@ -45,17 +45,12 @@ class ThenpingmeSyncTest extends TestCase
             Thenpingme::shouldReceive('translateExpression');
         });
 
-        $this->partialMock(Client::class, function ($mock) {
-            $mock
-                ->shouldReceive('sync')->once()->andReturnSelf()
-                ->shouldReceive('payload')->once()->andReturnSelf()
-                ->shouldReceive('dispatch')->once();
-        });
-
         $this
             ->artisan('thenpingme:sync')
             ->expectsOutput($this->translator->get('thenpingme::messages.successful_sync'))
             ->assertExitCode(0);
+
+        Bus::assertDispatched(ThenpingmePingJob::class);
 
         $this->assertFalse(config('thenpingme.queue_ping'));
     }


### PR DESCRIPTION
Serves also to account for situations where a queue might not be running, giving the appearance of setup being successful, but ultimately failing.

Fixes #10, which was ultimately caused by the the project being setup multiple times