### PR TITLE
[3.x] Make thenpingme:setup command dispatch immediately for instant feedback 

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  extensions: json, dom, curl, libxml, mbstring
+                  extensions: json, dom, curl, libxml, mbstring, fileinfo
                   coverage: none
 
             - name: Install dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,6 @@ jobs:
             fail-fast: false
             matrix:
                 php: [8.0, 7.4, 7.3]
-                laravel: [^8.0]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest]
 
@@ -37,9 +36,7 @@ jobs:
                   coverage: none
 
             - name: Install dependencies
-              run: |
-                  composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
-                  composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+              run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
             - name: Execute tests
               run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.6",
-        "mockery/mockery": "^1.3.1",
+        "mockery/mockery": "^1.4.1",
         "orchestra/testbench": "^6.0",
         "phpunit/phpunit": "^9.3",
         "rector/rector-prefixed": "^0.8.56",

--- a/composer.json
+++ b/composer.json
@@ -1,67 +1,67 @@
 {
-    "name": "thenpingme/laravel",
-    "type": "library",
-    "description": "Zero config scheduled task monitoring for Laravel",
-    "keywords": [
-        "thenpingme",
-        "laravel"
-    ],
-    "homepage": "https://github.com/thenpingme/laravel",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Michael Dyrynda",
-            "email": "michael@dyrynda.com.au",
-            "role": "Developer"
-        }
-    ],
-    "require": {
-        "php": "^7.3|^8.0",
-        "laravel/framework": "^8.0",
-        "lorisleiva/cron-translator": "^0.1.1",
-        "nesbot/carbon": "^2.33.0",
-        "nunomaduro/laravel-console-task": "^1.5",
-        "sixlive/dotenv-editor": "^1.2"
-    },
-    "require-dev": {
-        "ergebnis/composer-normalize": "^2.6",
-        "mockery/mockery": "^1.3.1",
-        "orchestra/testbench": "^6.0",
-        "phpunit/phpunit": "^9.3",
-        "rector/rector-prefixed": "^0.7.59",
-        "vimeo/psalm": "^3.13"
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "3.x-dev"
-        },
-        "laravel": {
-            "providers": [
-                "Thenpingme\\ThenpingmeServiceProvider"
-            ],
-            "aliases": {
-                "Laravel": "Thenpingme\\Facades\\Thenpingme"
-            }
-        }
-    },
-    "autoload": {
-        "psr-4": {
-            "Thenpingme\\": "src"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Thenpingme\\Tests\\": "tests"
-        }
-    },
-    "scripts": {
-        "normalise": "@composer normalize --indent-style space --indent-size 2 --ansi",
-        "psalm": "vendor/bin/psalm",
-        "rector": "vendor/bin/rector process src --ansi",
-        "test": "vendor/bin/phpunit --color=always",
-        "test-coverage": "vendor/bin/phpunit --color=always --coverage-html coverage"
+  "name": "thenpingme/laravel",
+  "type": "library",
+  "description": "Zero config scheduled task monitoring for Laravel",
+  "keywords": [
+    "thenpingme",
+    "laravel"
+  ],
+  "homepage": "https://github.com/thenpingme/laravel",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Michael Dyrynda",
+      "email": "michael@dyrynda.com.au",
+      "role": "Developer"
     }
+  ],
+  "require": {
+    "php": "^7.3 || ^8.0",
+    "laravel/framework": "^8.0",
+    "lorisleiva/cron-translator": "^0.1.1",
+    "nesbot/carbon": "^2.33.0",
+    "nunomaduro/laravel-console-task": "^1.5",
+    "sixlive/dotenv-editor": "^1.2"
+  },
+  "require-dev": {
+    "ergebnis/composer-normalize": "^2.6",
+    "mockery/mockery": "^1.3.1",
+    "orchestra/testbench": "^6.0",
+    "phpunit/phpunit": "^9.3",
+    "rector/rector-prefixed": "^0.8.56",
+    "vimeo/psalm": "^3.13"
+  },
+  "config": {
+    "sort-packages": true
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "3.x-dev"
+    },
+    "laravel": {
+      "providers": [
+        "Thenpingme\\ThenpingmeServiceProvider"
+      ],
+      "aliases": {
+        "Laravel": "Thenpingme\\Facades\\Thenpingme"
+      }
+    }
+  },
+  "autoload": {
+    "psr-4": {
+      "Thenpingme\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Thenpingme\\Tests\\": "tests"
+    }
+  },
+  "scripts": {
+    "normalise": "@composer normalize --indent-style space --indent-size 2 --ansi",
+    "psalm": "vendor/bin/psalm",
+    "rector": "vendor/bin/rector process src --ansi",
+    "test": "vendor/bin/phpunit --color=always",
+    "test-coverage": "vendor/bin/phpunit --color=always --coverage-html coverage"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "laravel/framework": "^8.0",
+        "laravel/framework": "^8.12",
         "lorisleiva/cron-translator": "^0.1.1",
         "nesbot/carbon": "^2.33.0",
         "nunomaduro/laravel-console-task": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -1,67 +1,67 @@
 {
-  "name": "thenpingme/laravel",
-  "type": "library",
-  "description": "Zero config scheduled task monitoring for Laravel",
-  "keywords": [
-    "thenpingme",
-    "laravel"
-  ],
-  "homepage": "https://github.com/thenpingme/laravel",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Michael Dyrynda",
-      "email": "michael@dyrynda.com.au",
-      "role": "Developer"
-    }
-  ],
-  "require": {
-    "php": "^7.3 || ^8.0",
-    "laravel/framework": "^8.0",
-    "lorisleiva/cron-translator": "^0.1.1",
-    "nesbot/carbon": "^2.33.0",
-    "nunomaduro/laravel-console-task": "^1.5",
-    "sixlive/dotenv-editor": "^1.2"
-  },
-  "require-dev": {
-    "ergebnis/composer-normalize": "^2.6",
-    "mockery/mockery": "^1.3.1",
-    "orchestra/testbench": "^6.0",
-    "phpunit/phpunit": "^9.3",
-    "rector/rector-prefixed": "^0.8.56",
-    "vimeo/psalm": "^3.13"
-  },
-  "config": {
-    "sort-packages": true
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "3.x-dev"
+    "name": "thenpingme/laravel",
+    "type": "library",
+    "description": "Zero config scheduled task monitoring for Laravel",
+    "keywords": [
+        "thenpingme",
+        "laravel"
+    ],
+    "homepage": "https://github.com/thenpingme/laravel",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Michael Dyrynda",
+            "email": "michael@dyrynda.com.au",
+            "role": "Developer"
+        }
+    ],
+    "require": {
+        "php": "^7.3 || ^8.0",
+        "laravel/framework": "^8.0",
+        "lorisleiva/cron-translator": "^0.1.1",
+        "nesbot/carbon": "^2.33.0",
+        "nunomaduro/laravel-console-task": "^1.5",
+        "sixlive/dotenv-editor": "^1.2"
     },
-    "laravel": {
-      "providers": [
-        "Thenpingme\\ThenpingmeServiceProvider"
-      ],
-      "aliases": {
-        "Laravel": "Thenpingme\\Facades\\Thenpingme"
-      }
+    "require-dev": {
+        "ergebnis/composer-normalize": "^2.6",
+        "mockery/mockery": "^1.3.1",
+        "orchestra/testbench": "^6.0",
+        "phpunit/phpunit": "^9.3",
+        "rector/rector-prefixed": "^0.8.56",
+        "vimeo/psalm": "^3.18|^4.0"
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.x-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Thenpingme\\ThenpingmeServiceProvider"
+            ],
+            "aliases": {
+                "Laravel": "Thenpingme\\Facades\\Thenpingme"
+            }
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Thenpingme\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Thenpingme\\Tests\\": "tests"
+        }
+    },
+    "scripts": {
+        "normalise": "@composer normalize --indent-style space --indent-size 2 --ansi",
+        "psalm": "vendor/bin/psalm",
+        "rector": "vendor/bin/rector process src --ansi",
+        "test": "vendor/bin/phpunit --color=always",
+        "test-coverage": "vendor/bin/phpunit --color=always --coverage-html coverage"
     }
-  },
-  "autoload": {
-    "psr-4": {
-      "Thenpingme\\": "src"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Thenpingme\\Tests\\": "tests"
-    }
-  },
-  "scripts": {
-    "normalise": "@composer normalize --indent-style space --indent-size 2 --ansi",
-    "psalm": "vendor/bin/psalm",
-    "rector": "vendor/bin/rector process src --ansi",
-    "test": "vendor/bin/phpunit --color=always",
-    "test-coverage": "vendor/bin/phpunit --color=always --coverage-html coverage"
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.3|^8.0",
         "laravel/framework": "^8.0",
         "lorisleiva/cron-translator": "^0.1.1",
         "nesbot/carbon": "^2.33.0",

--- a/src/Console/Commands/ThenpingmeSetupCommand.php
+++ b/src/Console/Commands/ThenpingmeSetupCommand.php
@@ -171,13 +171,17 @@ class ThenpingmeSetupCommand extends Command
 
     protected function setupInitialTasks(): bool
     {
+        config(['thenpingme.queue_ping' => false]);
+
         app(Client::class)
             ->setup()
             ->useSecret($this->option('tasks-only') ? Config::get('thenpingme.project_id') : $this->argument('project_id'))
-            ->payload(ThenpingmeSetupPayload::make(
-                Thenpingme::scheduledTasks(),
-                Config::get('thenpingme.signing_key') ?: $this->signingKey
-            )->toArray())
+            ->payload(
+                ThenpingmeSetupPayload::make(
+                    Thenpingme::scheduledTasks(),
+                    Config::get('thenpingme.signing_key') ?: $this->signingKey
+                )->toArray()
+            )
             ->dispatch();
 
         return true;

--- a/tests/ThenpingmeSyncTest.php
+++ b/tests/ThenpingmeSyncTest.php
@@ -4,11 +4,11 @@ namespace Thenpingme\Tests;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Translation\Translator;
-use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Str;
-use Thenpingme\Client\Client;
 use Thenpingme\Collections\ScheduledTaskCollection;
 use Thenpingme\Facades\Thenpingme;
+use Thenpingme\ThenpingmePingJob;
 
 class ThenpingmeSyncTest extends TestCase
 {
@@ -21,14 +21,14 @@ class ThenpingmeSyncTest extends TestCase
 
         $this->translator = $this->app->make(Translator::class);
 
-        Queue::fake();
-
         config(['thenpingme.api_url' => 'http://thenpingme.test/api']);
     }
 
     /** @test */
     public function it_fetches_tasks_to_be_synced()
     {
+        Bus::fake();
+
         config(['thenpingme.queue_ping' => true]);
 
         tap($this->app->make(Schedule::class), function ($schedule) {
@@ -45,17 +45,12 @@ class ThenpingmeSyncTest extends TestCase
             Thenpingme::shouldReceive('translateExpression');
         });
 
-        $this->partialMock(Client::class, function ($mock) {
-            $mock
-                ->shouldReceive('sync')->once()->andReturnSelf()
-                ->shouldReceive('payload')->once()->andReturnSelf()
-                ->shouldReceive('dispatch')->once();
-        });
-
         $this
             ->artisan('thenpingme:sync')
             ->expectsOutput($this->translator->get('thenpingme::messages.successful_sync'))
             ->assertExitCode(0);
+
+        Bus::assertDispatched(ThenpingmePingJob::class);
 
         $this->assertFalse(config('thenpingme.queue_ping'));
     }


### PR DESCRIPTION
Serves also to account for situations where a queue might not be running, giving the appearance of setup being successful, but ultimately failing.

Fixes #10, which was ultimately caused by the the project being setup multiple times