### PR TITLE
More robust support for filtering scheduled tasks

### DIFF
--- a/src/Payload/TaskPayload.php
+++ b/src/Payload/TaskPayload.php
@@ -43,10 +43,10 @@ class TaskPayload extends ThenpingmePayload
     private function isFiltered(): bool
     {
         return with(new ReflectionClass($this->task), function ($class) {
-            $filters = $class->getProperty('filters');
-            $filters->setAccessible(true);
-
-            return ! empty($filters->getValue($this->task));
+            return ! empty(array_merge(
+                tap($class->getProperty('filters'))->setAccessible(true)->getValue($this->task),
+                tap($class->getProperty('rejects'))->setAccessible(true)->getValue($this->task),
+            ));
         });
     }
 

--- a/tests/ThenpingmePayloadTest.php
+++ b/tests/ThenpingmePayloadTest.php
@@ -479,7 +479,10 @@ class ThenpingmePayloadTest extends TestCase
         putenv('SERVER_ADDR');
 
         // Fallback
-        if (($ip = gethostbyname($host)) !== '127.0.0.1') {
+        if (PHP_OS == 'Linux') {
+            // The only way to really test this works would be to duplicate the hostname
+            // lookup that is executed in ThenpingmePayload, which is also pointless.
+        } elseif (($ip = gethostbyname($host)) !== '127.0.0.1') {
             $this->assertEquals($ip, ThenpingmePayload::getIp($host));
         } else {
             $this->assertNull(ThenpingmePayload::getIp($host));

--- a/tests/ThenpingmePayloadTest.php
+++ b/tests/ThenpingmePayloadTest.php
@@ -85,6 +85,86 @@ class ThenpingmePayloadTest extends TestCase
     }
 
     /** @test */
+    public function it_determines_if_a_task_is_filtered_by_unlessBetween()
+    {
+        $task = $this->app->make(Schedule::class)
+            ->command('thenpingme:filtered')
+            ->hourly()
+            ->description('This is the description')
+            ->unlessBetween('00:00', '07:00');
+
+        tap(ThenpingmePayload::fromTask($task)->toArray(), function ($payload) use ($task) {
+            Assert::assertArraySubset([
+                'timezone' => '+00:00',
+                'type' => TaskIdentifier::TYPE_COMMAND,
+                'expression' => '0 * * * *',
+                'command' => 'thenpingme:filtered',
+                'maintenance' => false,
+                'without_overlapping' => false,
+                'on_one_server' => false,
+                'description' => 'This is the description',
+                'mutex' => Thenpingme::fingerprintTask($task),
+                'filtered' => true,
+                'run_in_background' => false,
+            ], $payload);
+        });
+    }
+
+    /** @test */
+    public function it_determines_if_a_task_is_filtered_by_skip()
+    {
+        $task = $this->app->make(Schedule::class)
+            ->command('thenpingme:filtered')
+            ->hourly()
+            ->description('This is the description')
+            ->skip(function () {
+                return true;
+            });
+
+        tap(ThenpingmePayload::fromTask($task)->toArray(), function ($payload) use ($task) {
+            Assert::assertArraySubset([
+                'timezone' => '+00:00',
+                'type' => TaskIdentifier::TYPE_COMMAND,
+                'expression' => '0 * * * *',
+                'command' => 'thenpingme:filtered',
+                'maintenance' => false,
+                'without_overlapping' => false,
+                'on_one_server' => false,
+                'description' => 'This is the description',
+                'mutex' => Thenpingme::fingerprintTask($task),
+                'filtered' => true,
+                'run_in_background' => false,
+            ], $payload);
+        });
+    }
+
+    /** @test */
+    public function it_determines_if_a_task_is_filtered_by_between()
+    {
+        $task = $this->app->make(Schedule::class)
+            ->command('thenpingme:filtered')
+            ->hourly()
+            ->description('This is the description')
+            ->between('07:00', '19:00');
+
+        tap(ThenpingmePayload::fromTask($task)->toArray(), function ($payload) use ($task) {
+            Assert::assertArraySubset([
+                'timezone' => '+00:00',
+                'type' => TaskIdentifier::TYPE_COMMAND,
+                'expression' => '0 * * * *',
+                'command' => 'thenpingme:filtered',
+                'maintenance' => false,
+                'without_overlapping' => false,
+                'on_one_server' => false,
+                'description' => 'This is the description',
+                'mutex' => Thenpingme::fingerprintTask($task),
+                'filtered' => true,
+                'run_in_background' => false,
+            ], $payload);
+        });
+    }
+
+    /** @test */
     public function it_determines_if_a_job_runs_in_the_background()
     {
         $task = $this->app->make(Schedule::class)


### PR DESCRIPTION
As reported (!114) via support, this PR adds more robust support for tasks that are filtered.

We should then support all of the filter/reject methods provided by Laravel:

* `when`
* `skip`
* `between`
* `unlessBetween`