### PR TITLE
Add missing import

### DIFF
--- a/src/ThenpingmePingJob.php
+++ b/src/ThenpingmePingJob.php
@@ -5,6 +5,7 @@ namespace Thenpingme;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Http;


### PR DESCRIPTION
This means that the client is not otherwise logging request exceptions, because PHP was looking for a `RequestException` in the current (`Thenpingme`) namespace 🤦 