### PR TITLE
Add the ability to override the configured project name

### DIFF
--- a/config/thenpingme.php
+++ b/config/thenpingme.php
@@ -6,6 +6,8 @@ return [
 
     'project_id' => env('THENPINGME_PROJECT_ID'),
 
+    'project_name' => env('THENPINGME_PROJECT_NAME', env('APP_NAME')),
+
     'signing_key' => env('THENPINGME_SIGNING_KEY'),
 
     'queue_ping' => env('THENPINGME_QUEUE_PING', true),

--- a/src/Payload/SyncPayload.php
+++ b/src/Payload/SyncPayload.php
@@ -32,7 +32,7 @@ class SyncPayload implements Arrayable
             ],
             'project' => array_filter([
                 'uuid' => Config::get('thenpingme.project_id'),
-                'name' => Config::get('app.name'),
+                'name' => Config::get('thenpingme.project_name'),
                 'release' => Config::get('thenpingme.release'),
                 'timezone' => Carbon::now()->timezone->toOffsetName(),
             ]),

--- a/src/Payload/ThenpingmePayload.php
+++ b/src/Payload/ThenpingmePayload.php
@@ -73,7 +73,7 @@ abstract class ThenpingmePayload implements Arrayable
             'environment' => app()->environment(),
             'project' => array_filter([
                 'uuid' => config('thenpingme.project_id'),
-                'name' => config('app.name'),
+                'name' => config('thenpingme.project_name'),
                 'release' => config('thenpingme.release'),
                 'timezone' => Carbon::now()->timezone->toOffsetName(),
             ]),

--- a/src/Payload/ThenpingmeSetupPayload.php
+++ b/src/Payload/ThenpingmeSetupPayload.php
@@ -36,7 +36,7 @@ class ThenpingmeSetupPayload implements Arrayable
             ],
             'project' => array_filter([
                 'uuid' => Config::get('thenpingme.project_id'),
-                'name' => Config::get('app.name'),
+                'name' => Config::get('thenpingme.project_name'),
                 'signing_key' => $this->signingKey,
                 'release' => Config::get('thenpingme.release'),
                 'timezone' => Carbon::now()->timezone->toOffsetName(),

--- a/tests/ThenpingmePayloadTest.php
+++ b/tests/ThenpingmePayloadTest.php
@@ -26,12 +26,12 @@ class ThenpingmePayloadTest extends TestCase
         parent::setUp();
 
         Config::set([
-            'app.name' => 'We changed the project name',
             'thenpingme.project_id' => 'abc123',
             'thenpingme.signing_key' => 'super-secret',
             'thenpingme.release' => 'this is the release',
         ]);
 
+        putenv('APP_NAME=We changed the project name');
         putenv('SERVER_ADDR=10.1.1.1');
     }
 
@@ -436,6 +436,8 @@ class ThenpingmePayloadTest extends TestCase
     /** @test */
     public function it_generates_a_sync_payload()
     {
+        config(['thenpingme.project_name' => 'Some other project name']);
+
         $schedule = $this->app->make(Schedule::class);
 
         $events = ScheduledTaskCollection::make([
@@ -449,7 +451,7 @@ class ThenpingmePayloadTest extends TestCase
                 ],
                 'project' => [
                     'uuid' => 'abc123',
-                    'name' => 'We changed the project name',
+                    'name' => 'Some other project name',
                     'release' => 'this is the release',
                     'timezone' => '+00:00',
                 ],


### PR DESCRIPTION
By default, thenping.me uses the configured `APP_NAME` (`app.name`) value for setting the project name within the UI.

Whilst this means there is no configuration required to get started, it does limit the ability to differentiate between deployed instances of the same application for multiple environments or clients.

This is a backwards compatible change that introduces a `thenpingme.project_name` configuration value that can be set with the `THENPINGME_PROJECT_NAME` environment variable and falls back to `app.name` that is set by the `APP_NAME` environment variable.

Fixes #26
