### PR TITLE
Improve describing anonymous closures to thenping.me

### DIFF
--- a/tests/ThenpingmePayloadTest.php
+++ b/tests/ThenpingmePayloadTest.php
@@ -500,4 +500,27 @@ class ThenpingmePayloadTest extends TestCase
             $this->assertNull(ThenpingmePayload::getIp($host));
         }
     }
+
+    /** @test */
+    public function it_sets_a_file_reference_for_closure_tasks()
+    {
+        $task = $this->app->make(Schedule::class)->call(function () {
+            echo 'anonymous';
+        });
+
+        // This is janky; don't put anything before here without updating 
+        // the start variable, otherwise the test assertion will fail.
+        $start = __LINE__ - 6;
+        $end = $start + 2;
+
+        tap(ThenpingmePayload::fromTask($task)->toArray(), function ($payload) use ($start, $end) {
+            Assert::assertArraySubset([
+                'command' => __CLASS__.":{$start} to {$end}",
+                'extra' => [
+                    'file' => __CLASS__,
+                    'line' => "{$start} to {$end}",
+                ],
+            ], $payload);
+        });
+    }
 }


### PR DESCRIPTION
For any tasks that are scheduled as closures in `App\Console\Kernel`, they are currently identified as `null` to thenping.me, which makes them impossible to review within the UI.

```php
$schedule->call(function () {
    echo 'some test';
});
```

This change will look for closures that have neither discernible `command` nor `description` fields and use the class path and line numbers as the command i.e. `App\Console\Kernel:40 to 42`.

By doing so, we identify exactly where the task is (kept up to date via `thenpingme:sync`) and make it possible to view the tasks via the UI.

Before:

```
❯ php artisan thenpingme:schedule                                                                                                                                                                                                                                                                       │
+--+-----------------------------+--------------+-------------+---------------------+---------------------+                                                                                                                                                                                   │
|  | Command                     | Interval     | Description | Last Run            | Next Due            |                                                                                                                                                                                   │
+--+-----------------------------+--------------+-------------+---------------------+---------------------+                                                                                                                                                                                   │
|  |                             | Every minute |             | 2021-10-23 06:46:00 | 2021-10-23 06:48:00 |                                                                                                                                                                                   │
+--+-----------------------------+--------------+-------------+---------------------+---------------------+
```

After:

```
❯ php artisan thenpingme:schedule                                                                                                                                                                                                                                                                       │
+--+-----------------------------+--------------+-------------+---------------------+---------------------+                                                                                                                                                                                   │
|  | Command                     | Interval     | Description | Last Run            | Next Due            |                                                                                                                                                                                   │
+--+-----------------------------+--------------+-------------+---------------------+---------------------+                                                                                                                                                                                   │
|  | App\Console\Kernel:40 to 42 | Every minute |             | 2021-10-23 06:46:00 | 2021-10-23 06:48:00 |                                                                                                                                                                                   │
+--+-----------------------------+--------------+-------------+---------------------+---------------------+
```