### PR TITLE
Add support for skipping monitoring of tasks

### DIFF
--- a/src/Collections/ScheduledTaskCollection.php
+++ b/src/Collections/ScheduledTaskCollection.php
@@ -11,6 +11,14 @@ use Thenpingme\Payload\TaskPayload;
 
 class ScheduledTaskCollection extends Collection
 {
+    public function __construct($items = [])
+    {
+        parent::__construct(array_filter($this->getArrayableItems($items), function ($event) {
+            return ! isset($event->thenpingmeOptions)
+                || $event->thenpingmeOptions['skip'] === false;
+        }));
+    }
+
     public function collisions(): ScheduledTaskCollection
     {
         return ScheduledTaskCollection::make($this

--- a/src/Scheduling/Event.php
+++ b/src/Scheduling/Event.php
@@ -11,12 +11,14 @@ class Event
         return function (
             ?int $grace_period = null,
             ?int $allowed_run_time = null,
-            ?int $notify_after_consecutive_alerts = null
+            ?int $notify_after_consecutive_alerts = null,
+            ?bool $skip = false,
         ) {
             $this->thenpingmeOptions = [
                 'grace_period' => $grace_period,
                 'allowed_run_time' => $allowed_run_time,
                 'notify_after_consecutive_alerts' => $notify_after_consecutive_alerts,
+                'skip' => $skip,
             ];
 
             return $this;


### PR DESCRIPTION
Now that we support configuring task settings from the application side, add the ability to specify tasks that should not be monitored.

This is done via the existing `thenpingme` macro method.

```php
// app/Console/Kernel.php

protected function schedule(Schedule $schedule)
{
    $schedule->command('first:command');

    $schedule->command('second:command')->thenpingme(skip: true);

    $schedule->command('third:command')->thenpingme(skip: false);
}
```

For calls to `thenpingme:setup`, `thenpingme:sync`, or `thenpingme:schedule` commands, `first:command` and `third:command` will be available for processing (either push to thenping.me or shown in the schedule list), however, `second:command` will be omitted.

For a task that was active, then marked as `skip: true`, it will (currently) be _removed_ from thenping.me.

Closes #32