### PR TITLE
Handle missing project name in setup command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,11 @@
         "vimeo/psalm": "^3.13|^4.0"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true,
+            "pestphp/pest-plugin": true
+        }
     },
     "extra": {
         "branch-alias": {

--- a/resources/lang/en/translations.php
+++ b/resources/lang/en/translations.php
@@ -18,6 +18,8 @@ return [
 
     'invalid_signer' => ':concrete does not implement :contract',
 
+    'project_name_not_set' => 'A non-empty project name is required. Please check config/thenpingme.php and the corresponding environment variables, then run:',
+
     'env_missing' => 'The .env file is missing. Please add the following lines to your configuration, then run:',
 
     'signing_key_environment' => 'The .env file is missing. Please add the following lines to your configuration',

--- a/src/Console/Commands/ThenpingmeSetupCommand.php
+++ b/src/Console/Commands/ThenpingmeSetupCommand.php
@@ -87,6 +87,13 @@ class ThenpingmeSetupCommand extends Command
             });
         }
 
+        if (trim($this->config->get('thenpingme.project_name')) === '') {
+            $this->error($this->translator->get('thenpingme::translations.project_name_not_set'));
+            $this->info('    php artisan thenpingme:setup --tasks-only');
+
+            return 1;
+        }
+
         $this->task(
             $this->translator->get('thenpingme::translations.initial_setup', [
                 'url' => parse_url($this->config->get('thenpingme.api_url'), PHP_URL_HOST),

--- a/src/Console/Commands/ThenpingmeSetupCommand.php
+++ b/src/Console/Commands/ThenpingmeSetupCommand.php
@@ -4,9 +4,9 @@ namespace Thenpingme\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Facades\Config;
 use InvalidArgumentException;
 use sixlive\DotenvEditor\DotenvEditor;
 use Thenpingme\Client\Client;
@@ -24,6 +24,9 @@ class ThenpingmeSetupCommand extends Command
     protected $signature = 'thenpingme:setup {project_id?  : The UUID of the thenping.me project you are setting up}
                                              {--tasks-only : Only send your application tasks to thenping.me}';
 
+    /** @var \Illuminate\Contracts\Config\Repository */
+    protected $config;
+
     /** @var \Illuminate\Console\Scheduling\Schedule */
     protected $schedule;
 
@@ -36,11 +39,12 @@ class ThenpingmeSetupCommand extends Command
     /** @var \Illuminate\Contracts\Translation\Translator */
     protected $translator;
 
-    public function __construct(Translator $translator)
+    public function __construct(Translator $translator, Repository $config)
     {
         parent::__construct();
 
         $this->translator = $translator;
+        $this->config = $config;
     }
 
     public function handle(Schedule $schedule)
@@ -85,7 +89,7 @@ class ThenpingmeSetupCommand extends Command
 
         $this->task(
             $this->translator->get('thenpingme::translations.initial_setup', [
-                'url' => parse_url(Config::get('thenpingme.api_url'), PHP_URL_HOST),
+                'url' => parse_url($this->config->get('thenpingme.api_url'), PHP_URL_HOST),
             ]),
             function () {
                 return $this->setupInitialTasks();
@@ -100,12 +104,12 @@ class ThenpingmeSetupCommand extends Command
 
     protected function thenpingmeDisabled(): bool
     {
-        return Config::get('thenpingme.enabled') === false;
+        return $this->config->get('thenpingme.enabled') === false;
     }
 
     protected function canBeSetup(): bool
     {
-        if ($this->option('tasks-only') && Config::get('thenpingme.project_id')) {
+        if ($this->option('tasks-only') && $this->config->get('thenpingme.project_id')) {
             return true;
         }
 
@@ -133,7 +137,7 @@ class ThenpingmeSetupCommand extends Command
             $editor->save();
         });
 
-        Config::set([
+        $this->config->set([
             'thenpingme.project_id' => $this->argument('project_id'),
             'thenpingme.signing_key' => $this->signingKey,
         ]);
@@ -186,11 +190,11 @@ class ThenpingmeSetupCommand extends Command
 
         app(Client::class)
             ->setup()
-            ->useSecret($this->option('tasks-only') ? Config::get('thenpingme.project_id') : $this->argument('project_id'))
+            ->useSecret($this->option('tasks-only') ? $this->config->get('thenpingme.project_id') : $this->argument('project_id'))
             ->payload(
                 ThenpingmeSetupPayload::make(
                     Thenpingme::scheduledTasks(),
-                    Config::get('thenpingme.signing_key') ?: $this->signingKey
+                    $this->config->get('thenpingme.signing_key') ?: $this->signingKey
                 )->toArray()
             )
             ->dispatch();

--- a/tests/ThenpingmeSetupTest.php
+++ b/tests/ThenpingmeSetupTest.php
@@ -212,6 +212,21 @@ class ThenpingmeSetupTest extends TestCase
         Bus::assertDispatched(ThenpingmePingJob::class);
     }
 
+    /** @test */
+    public function it_handles_checking_for_project_name()
+    {
+        config(['thenpingme.project_name' => null]);
+
+        Thenpingme::shouldReceive('generateSigningKey')->once()->andReturn('this-is-the-signing-secret');
+        Thenpingme::shouldReceive('scheduledTasks')->andReturn(new ScheduledTaskCollection());
+
+        $this->artisan('thenpingme:setup aaa-bbbb-c1c1c1-ddd-ef1')
+            ->expectsOutput($this->translator->get('thenpingme::translations.project_name_not_set'))
+            ->assertExitCode(1);
+
+        Bus::assertNotDispatched(ThenpingmePingJob::class);
+    }
+
     protected function loadEnv($file)
     {
         return tap(new DotenvEditor)->load($file);


### PR DESCRIPTION
thenping.me requires that a project name is set.

This is handled in the client package via `thenpingme.project_name`, which is defined as `THENPINGME_PROJECT_NAME` - allowing per-environment overrides, where some people deploy the same application to different environments or for different clients - and falling back to the `APP_NAME` by default.

If both of these values are empty, the `project_name` value reaches thenping.me as an unset value, and subsequent validation causes the project setup to fail silently.

This change puts a check within the `thenpingme:setup` command directly. Better user experience, less support queries.
